### PR TITLE
Removed `to_string()` calls to avoid uneccesary allocations

### DIFF
--- a/src/ip/mod.rs
+++ b/src/ip/mod.rs
@@ -2,7 +2,7 @@ pub fn is_valid(address: &str) -> bool {
     let octets = address.split(".");
     let mut octet_count: u8 = 0;
     for byte in octets {
-        match byte.to_string().parse::<u8>() {
+        match byte.parse::<u8>() {
             Err(_) => return false,
             Ok(_)  => octet_count += 1,
         }
@@ -27,7 +27,7 @@ pub fn make_mask_from_string(address: &str) -> u32 {
     let mut octet_count: u8 = 3;
     let mut mask: u32 = 0;
     for byte in octets {
-        let ibyte = byte.to_string().parse::<u8>().unwrap();
+        let ibyte = byte.parse::<u8>().unwrap();
         mask += 256u32.pow(octet_count as u32) * ibyte as u32;
         if octet_count > 0 {
             octet_count -= 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ fn main() {
 
                 let address_parts: Vec<&str> = args[1].split('/').collect();
                 if address_parts.len() == 2 {
-                    if ip::is_valid(address_parts[0]) && address_parts[1].to_string().parse::<u8>().unwrap() < 33 {
-                        let mask_from_cidr = match ip::make_mask_from_cidr(address_parts[1].to_string().parse::<u8>().unwrap()) {
+                    if ip::is_valid(address_parts[0]) && address_parts[1].parse::<u8>().unwrap() < 33 {
+                        let mask_from_cidr = match ip::make_mask_from_cidr(address_parts[1].parse::<u8>().unwrap()) {
                             Ok(m) => m,
                             Err(_) => {
                                 println!("Your CIDR is too high");


### PR DESCRIPTION
The `.to_string()` conversions aren't necessary because `&str` implements `.parse::<u8>()`, too. Calling `.to_string()` will cause heap allocations that aren't needed.